### PR TITLE
Refinement of Player Database Initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.sausagedev</groupId>
   <artifactId>SoSeller</artifactId>
-  <version>1.9.9</version>
+  <version>1.9.9.1</version>
   <packaging>jar</packaging>
 
   <name>SoSeller</name>

--- a/src/main/java/org/sausagedev/soseller/SoSeller.java
+++ b/src/main/java/org/sausagedev/soseller/SoSeller.java
@@ -12,6 +12,7 @@ import org.sausagedev.soseller.commands.TabCompleter;
 import org.sausagedev.soseller.listeners.AutoSellListener;
 import org.sausagedev.soseller.listeners.FuctionsListener;
 import org.sausagedev.soseller.listeners.MenuListener;
+import org.sausagedev.soseller.listeners.PlayerJoinListener;
 import org.sausagedev.soseller.utils.AutoSell;
 import org.sausagedev.soseller.utils.Config;
 import org.sausagedev.soseller.utils.Utils;
@@ -81,6 +82,7 @@ public final class SoSeller extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new FuctionsListener(), this);
         getServer().getPluginManager().registerEvents(new MenuListener(), this);
         getServer().getPluginManager().registerEvents(new AutoSellListener(), this);
+        getServer().getPluginManager().registerEvents(new PlayerJoinListener(), this);
         saveDefaultConfig();
         createDataBase();
 

--- a/src/main/java/org/sausagedev/soseller/listeners/PlayerJoinListener.java
+++ b/src/main/java/org/sausagedev/soseller/listeners/PlayerJoinListener.java
@@ -1,0 +1,17 @@
+package org.sausagedev.soseller.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.sausagedev.soseller.utils.Database;
+
+import java.util.UUID;
+
+public class PlayerJoinListener implements Listener {
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        UUID uuid = event.getPlayer().getUniqueId();
+        Database.checkAndCreate(uuid);
+    }
+}

--- a/src/main/java/org/sausagedev/soseller/utils/Database.java
+++ b/src/main/java/org/sausagedev/soseller/utils/Database.java
@@ -38,6 +38,7 @@ public class Database {
             }
         });
     }
+
     public static void checkAndCreate(UUID uuid) {
         CompletableFuture.runAsync(() -> {
             try {

--- a/src/main/java/org/sausagedev/soseller/utils/Database.java
+++ b/src/main/java/org/sausagedev/soseller/utils/Database.java
@@ -88,7 +88,7 @@ public class Database {
                 ps2.close();
                 ps.close();
             } catch (SQLException e) {
-                main.getLogger().severe("SQLException error: " + e.getCause());
+                main.getLogger().severe("SQLException errors: " + e.getCause());
                 e.printStackTrace();
             }
         });

--- a/src/main/java/org/sausagedev/soseller/utils/Database.java
+++ b/src/main/java/org/sausagedev/soseller/utils/Database.java
@@ -38,6 +38,37 @@ public class Database {
             }
         });
     }
+    public static void checkAndCreate(UUID uuid) {
+        CompletableFuture.runAsync(() -> {
+            try {
+                Connection connection = main.getConnection();
+                PreparedStatement ps = connection.prepareStatement(
+                        "SELECT uuid FROM database WHERE uuid = ?"
+                );
+                ps.setString(1, uuid.toString());
+                ResultSet rs = ps.executeQuery();
+                if (!rs.next()) {
+                    Player player = main.getServer().getPlayer(uuid);
+                    if (player != null) {
+                        PreparedStatement insertPs = connection.prepareStatement(
+                                "INSERT INTO database(uuid, nick, items, boost, autosell) " +
+                                        "VALUES (?, ?, 0, 1, 0)"
+                        );
+                        insertPs.setString(1, uuid.toString());
+                        insertPs.setString(2, player.getName());
+                        insertPs.executeUpdate();
+                        insertPs.close();
+                    }
+                }
+
+                ps.close();
+                rs.close();
+
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        });
+    }
     public static void setAutoSellBought(UUID uuid, boolean autoSell) {
         CompletableFuture.runAsync(() -> {
             try {


### PR DESCRIPTION
Previously, the database entry for a player was only created after their first transaction, causing initial actions (like selling items or buying auto-seller) to be ignored. Now, checkAndCreate(UUID uuid) ensures that player data is inserted into the database as soon as they join the server, preventing lost transactions and requiring duplicate purchases.